### PR TITLE
Add resetChatBoxIdGenerator for testing and update TestChatBox

### DIFF
--- a/src/Common/ChatBox/ChatBox.java
+++ b/src/Common/ChatBox/ChatBox.java
@@ -15,6 +15,11 @@ public class ChatBox implements Serializable {
 
     // Static atomic integer for generating unique chatBoxIDs
     private static final AtomicInteger chatBoxIdGenerator = new AtomicInteger(0);
+    
+    // Reset the chatBoxIdGenerator for testing
+    public static void resetChatBoxIdGenerator() {
+        chatBoxIdGenerator.set(0);
+    }
 
     // Attributes
     private int chatBoxID;

--- a/src/Testing/TestChatBox.java
+++ b/src/Testing/TestChatBox.java
@@ -22,6 +22,7 @@ class TestChatBox {
 
     @BeforeEach
     public void setUp() {
+    	ChatBox.resetChatBoxIdGenerator(); 
         user1 = new User("Sally", "pass123");
         user2 = new User("Bob", "pass456");
         chatBox = new ChatBox("Test ChatBox");


### PR DESCRIPTION
Added a resetChatBoxIdGenerator method to ChatBox.java so we can reset the ID counter during tests.
Updated TestChatBox.java to call the reset method before each test to make sure the chatBoxID starts fresh every time so the tests are consistent.
This change is only for jUnit testing